### PR TITLE
Add signed release generation with keystore support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.env
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,96 @@
-prepairing stuff
+# AppMaker WebView Studio
+
+AppMaker WebView Studio is a lightweight Python + HTML tool that generates fully configured
+Android WebView wrapper projects. Each generated project contains a self-updating policy
+manifest so you can stay compliant when Google updates their SDK or Play policy
+requirements.
+
+## Features
+
+- Intuitive web UI powered by Flask for configuring your Android WebView app.
+- In-memory ZIP generation of a Gradle project with Kotlin activity boilerplate.
+- Optional signed release builder that bundles a keystore, certificate summary, and ready-to-upload APK/AAB outputs when Android tooling is available.
+- Bundled update script and `/api/sdk-rules` endpoint to keep Google policy data current.
+- Automatic refresh mechanism that caches the latest rules locally with graceful fallbacks.
+
+## Getting started
+
+1. Create a virtual environment and install dependencies:
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+2. Launch the development server:
+
+   ```bash
+   flask --app app run --reload
+   ```
+
+3. Open `http://127.0.0.1:5000` and fill out the form to generate a project.
+4. Use the **Build signed release package** button after expanding the advanced signing panel to request a keystore, certificate summary, and release artifacts.
+5. Use the **Refresh rules from Google** button to pull down the most recent SDK guidance.
+6. Each generated ZIP includes `tools/update_rules.py` so the Android project can update itself
+   before release.
+
+## Generating signed releases
+
+AppMaker can attempt to build a signed release bundle directly from the web UI. When you provide
+keystore credentials in the advanced section and click **Build signed release package**, the server:
+
+1. Generates a secure PKCS#12 keystore and `keystore.properties` wired into the Gradle project.
+2. Produces a certificate summary (`RELEASE_CERTIFICATE.txt`) so you can archive signing
+   fingerprints.
+3. Runs `assembleRelease` and `bundleRelease` (if Gradle and the Android SDK are installed on the
+   host) and packages any resulting APK/AAB files inside the download alongside the build log.
+
+If the host environment lacks the Android toolchain, the download still includes the full project,
+keystore, and a `tools/build_release.sh` helper script. Install Android Studio or the command line
+SDK tools, set `ANDROID_HOME`/`ANDROID_SDK_ROOT`, then execute:
+
+```bash
+cd project
+./tools/build_release.sh
+```
+
+The script prefers the Gradle wrapper when available and falls back to a system-wide `gradle`
+binary.
+
+### Environment variables
+
+- `SDK_RULE_SOURCE` – Override the remote JSON manifest endpoint.
+- `APPMAKER_SECRET` – Secret key for Flask session/flash support.
+- `PORT` and `FLASK_DEBUG` – Override server defaults when running `python app.py` directly.
+
+## API
+
+`GET /api/sdk-rules` returns the cached manifest, making it easy to integrate automated
+compliance checks into your pipeline.
+
+```json
+{
+  "rules": {
+    "version": "2024.04",
+    "updated": "2024-04-10T12:00:00Z",
+    "requirements": [
+      "Target API level 34 or above for new submissions.",
+      "Declare data safety information for WebView usage in Play Console.",
+      "Audit embedded web content for third-party cookies and trackers."
+    ],
+    "notes": [
+      "This offline cache is bundled so AppMaker can start even without network access.",
+      "Use the Refresh rules button to download the latest Android policy manifest."
+    ]
+  },
+  "source": "https://raw.githubusercontent.com/GoogleChromeLabs/llms/main/android_webview_rules.json"
+}
+```
+
+> **Tip:** Deploy AppMaker behind a scheduler (such as cron or GitHub Actions) that hits
+> `/refresh-rules` so the manifest automatically updates whenever Google publishes new rules.
+
+## License
+
+This project is provided under the MIT license.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,782 @@
+import io
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import zipfile
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, List, Tuple
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+from flask import (
+    Flask,
+    flash,
+    jsonify,
+    redirect,
+    render_template,
+    Response,
+    request,
+    send_file,
+    url_for,
+)
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import pkcs12
+from cryptography.x509.oid import NameOID
+
+APP_ROOT = Path(__file__).parent
+DATA_PATH = APP_ROOT / "data" / "sdk_rules.json"
+DEFAULT_RULE_SOURCE = (
+    "https://raw.githubusercontent.com/GoogleChromeLabs/llms/main/android_webview_rules.json"
+)
+
+app = Flask(__name__)
+app.secret_key = os.environ.get("APPMAKER_SECRET", "change-me")
+
+
+class RuleMonitor:
+    """Simple helper that keeps a cached copy of the Android policy manifest."""
+
+    def __init__(self, local_path: Path, remote_source: str) -> None:
+        self.local_path = local_path
+        self.remote_source = remote_source
+        self._cache: Dict[str, object] | None = None
+
+    def load(self) -> Dict[str, object]:
+        if self._cache is not None:
+            return self._cache
+        self._cache = self._load_from_disk()
+        return self._cache
+
+    def refresh(self) -> Dict[str, object]:
+        """Attempt to refresh rules from the remote source, falling back to disk."""
+        try:
+            data = self._download_remote_manifest()
+            self.local_path.parent.mkdir(parents=True, exist_ok=True)
+            self.local_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+            self._cache = data
+            return data
+        except URLError as exc:
+            app.logger.warning("Network issue refreshing SDK rules: %s", exc)
+        except Exception as exc:  # noqa: BLE001 - we want to surface the error message
+            app.logger.warning("Failed to refresh SDK rules: %s", exc)
+        data = self._load_from_disk()
+        self._cache = data
+        return data
+
+    def _load_from_disk(self) -> Dict[str, object]:
+        if not self.local_path.exists():
+            return {
+                "version": "0.0.0",
+                "updated": datetime.utcnow().isoformat() + "Z",
+                "notes": [
+                    "No official rules available. Check your network connection or set ``SDK_RULE_SOURCE``.",
+                ],
+                "requirements": [],
+            }
+        return json.loads(self.local_path.read_text(encoding="utf-8"))
+
+    def _download_remote_manifest(self) -> Dict[str, object]:
+        headers = {"User-Agent": "AppMakerWebViewStudio/1.0"}
+        request = Request(self.remote_source, headers=headers)
+        with urlopen(request, timeout=5) as response:  # noqa: S310 - controlled URL
+            charset = response.headers.get_content_charset() or "utf-8"
+            data = json.loads(response.read().decode(charset))
+        return data
+
+
+rule_monitor = RuleMonitor(
+    DATA_PATH,
+    os.environ.get("SDK_RULE_SOURCE", DEFAULT_RULE_SOURCE),
+)
+
+
+def validate_package_name(package_name: str) -> bool:
+    pattern = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)+$")
+    return bool(pattern.match(package_name))
+
+
+def sanitize_class_name(app_name: str) -> str:
+    cleaned = re.sub(r"[^0-9a-zA-Z]+", " ", app_name).title().replace(" ", "")
+    if not cleaned:
+        cleaned = "AppShell"
+    if cleaned[0].isdigit():
+        cleaned = f"App{cleaned}"
+    return cleaned
+
+
+def create_project_files(
+    app_name: str,
+    package_name: str,
+    start_url: str,
+    rules: Dict[str, object],
+    signing_config: Dict[str, str] | None = None,
+) -> Dict[str, str]:
+    files: Dict[str, str] = {}
+    rules_summary = "\n".join(
+        f"- {item}" for item in rules.get("requirements", [])
+    ) or "- Stay informed by reviewing the Android developer blog regularly."
+    class_base = sanitize_class_name(app_name)
+    activity_class = f"{class_base}Activity"
+
+    files["settings.gradle"] = f"""\
+rootProject.name = \"{app_name}\"
+include(\":app\")
+"""
+
+    files["gradle.properties"] = """\
+android.useAndroidX=true
+android.enableJetifier=true
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+"""
+
+    files["build.gradle"] = """\
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.3.2'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.23"
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+"""
+
+    files["app/build.gradle"] = f"""\
+import java.io.FileInputStream
+import java.util.Properties
+
+plugins {{
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}}
+
+def keystorePropertiesFile = rootProject.file("keystore.properties")
+def keystoreProperties = new Properties()
+if (keystorePropertiesFile.exists()) {{
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}}
+
+android {{
+    namespace '{package_name}'
+    compileSdk 34
+
+    defaultConfig {{
+        applicationId '{package_name}'
+        minSdk 24
+        targetSdk 34
+        versionCode 1
+        versionName "1.0"
+
+        vectorDrawables {{
+            useSupportLibrary true
+        }}
+    }}
+
+    signingConfigs {{
+        release {{
+            if (keystoreProperties.containsKey("storeFile")) {{
+                storeFile = file(keystoreProperties.getProperty("storeFile"))
+                storePassword = keystoreProperties.getProperty("storePassword")
+                keyAlias = keystoreProperties.getProperty("keyAlias")
+                keyPassword = keystoreProperties.getProperty(
+                    "keyPassword",
+                    keystoreProperties.getProperty("storePassword"),
+                )
+                storeType = keystoreProperties.getProperty("storeType", "pkcs12")
+                enableV1Signing = true
+                enableV2Signing = true
+            }}
+        }}
+    }}
+
+    buildTypes {{
+        release {{
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            if (keystoreProperties.containsKey("storeFile")) {{
+                signingConfig signingConfigs.release
+            }}
+        }}
+        debug {{
+            applicationIdSuffix ".debug"
+            versionNameSuffix "-debug"
+        }}
+    }}
+
+    compileOptions {{
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }}
+    kotlinOptions {{
+        jvmTarget = '17'
+    }}
+}}
+
+dependencies {{
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.11.0'
+}}
+"""
+
+    files["app/src/main/AndroidManifest.xml"] = f"""\
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="{package_name}">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:allowBackup="true"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:usesCleartextTraffic="true"
+        android:theme="@style/Theme.AppMaker">
+        <activity
+            android:name=".{activity_class}"
+            android:exported="true"
+            android:configChanges="keyboardHidden|orientation|screenSize"
+            android:usesCleartextTraffic="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>
+"""
+
+    files["app/src/main/java/{}/{}.kt".format(
+        package_name.replace(".", "/"), activity_class
+    )] = f"""\
+package {package_name}
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.appcompat.app.AppCompatActivity
+
+class {activity_class} : AppCompatActivity() {{
+
+    @SuppressLint("SetJavaScriptEnabled")
+    override fun onCreate(savedInstanceState: Bundle?) {{
+        super.onCreate(savedInstanceState)
+        val webView = WebView(this)
+        setContentView(webView)
+
+        val settings: WebSettings = webView.settings
+        settings.javaScriptEnabled = true
+        settings.domStorageEnabled = true
+        settings.loadsImagesAutomatically = true
+
+        webView.webViewClient = WebViewClient()
+        webView.loadUrl("{start_url}")
+    }}
+}}
+"""
+
+    files["app/src/main/res/values/strings.xml"] = f"""\
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">{app_name}</string>
+</resources>
+"""
+
+    files["app/src/main/res/values/themes.xml"] = """\
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.AppMaker" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowBackground">@color/app_background</item>
+        <item name="android:navigationBarColor">@android:color/black</item>
+        <item name="android:navigationBarIconColor">@android:color/white</item>
+        <item name="android:forceDarkAllowed">false</item>
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+</resources>
+"""
+
+    files["app/src/main/res/values-night/themes.xml"] = """\
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.AppMaker" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:forceDarkAllowed">true</item>
+        <item name="android:windowBackground">@android:color/black</item>
+    </style>
+</resources>
+"""
+
+    files["app/src/main/res/values/colors.xml"] = """\
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="app_background">#FFFFFFFF</color>
+</resources>
+"""
+
+    files["app/src/main/res/xml/data_extraction_rules.xml"] = """\
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <include domain="file" path="." />
+    </cloud-backup>
+</data-extraction-rules>
+"""
+
+    files["app/src/main/res/xml/backup_rules.xml"] = """\
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <include domain="file" path="." />
+</full-backup-content>
+"""
+
+    files["app/proguard-rules.pro"] = "# Keep default ProGuard rules.\n"
+
+    files["README.md"] = f"""\
+# {app_name}
+
+Generated with **AppMaker WebView Studio**.
+
+## Getting Started
+
+1. Install [Android Studio](https://developer.android.com/studio).
+2. Open this project folder.
+3. Update the application ID if you rename the package.
+4. Customize icons under `app/src/main/res/mipmap-*`.
+5. Build and run on a device or emulator.
+
+## WebView configuration
+
+- Launch URL: `{start_url}`
+- JavaScript and DOM storage enabled by default.
+
+## Compliance and Google Play rules
+
+This project bundles the latest policy manifest that the AppMaker backend was aware of when
+it generated your project. Run the included script to refresh the requirements before
+shipping:
+
+```bash
+python tools/update_rules.py
+```
+
+Latest known requirements:
+{rules_summary}
+"""
+
+    files["tools/update_rules.py"] = f"""\
+#!/usr/bin/env python3
+\"\"\"Refresh Android rules for this template.\"\"\"
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+REMOTE_SOURCE = os.environ.get(
+    "SDK_RULE_SOURCE",
+    "{rule_monitor.remote_source}",
+)
+OUTPUT = Path(__file__).resolve().parents[1] / "android_rules.json"
+
+
+def fetch_rules() -> dict:
+    headers = {"User-Agent": "AppMakerWebViewStudio/1.0"}
+    request = Request(REMOTE_SOURCE, headers=headers)
+    with urlopen(request, timeout=10) as response:  # noqa: S310 - controlled URL
+        charset = response.headers.get_content_charset() or "utf-8"
+        return json.loads(response.read().decode(charset))
+
+
+def main() -> None:
+    try:
+        data = fetch_rules()
+    except URLError as exc:
+        raise SystemExit(f"Failed to download rules: {exc}")
+    OUTPUT.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    print(f"Updated rules: version={{data.get('version')}}")
+
+
+if __name__ == "__main__":
+    main()
+"""
+
+    files["android_rules.json"] = json.dumps(rules, indent=2)
+
+    files["tools/build_release.sh"] = """\
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -x "./gradlew" ]; then
+  ./gradlew assembleRelease bundleRelease
+elif command -v gradle >/dev/null 2>&1; then
+  gradle assembleRelease bundleRelease
+else
+  echo "Gradle is not available. Install Gradle or Android Studio to build releases." >&2
+  exit 1
+fi
+"""
+
+    if signing_config:
+        keystore_lines = [
+            f"storeFile={signing_config['store_file']}",
+            f"storePassword={signing_config['store_password']}",
+            f"keyAlias={signing_config['key_alias']}",
+            f"keyPassword={signing_config['key_password']}",
+            f"storeType={signing_config.get('store_type', 'pkcs12')}",
+        ]
+        files["keystore.properties"] = "\n".join(keystore_lines) + "\n"
+
+    return files
+
+
+def build_project_zip(app_name: str, package_name: str, start_url: str, rules: Dict[str, object]) -> io.BytesIO:
+    """Create an Android project zip configured for the provided parameters."""
+    files = create_project_files(app_name, package_name, start_url, rules)
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, mode="w") as archive:
+        for path, content in files.items():
+            archive.writestr(path, content)
+    buffer.seek(0)
+    return buffer
+
+
+def create_release_keystore(
+    alias: str,
+    password: str,
+    common_name: str,
+    organization: str,
+    country: str,
+    validity_days: int,
+) -> Tuple[bytes, x509.Certificate]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name_attributes = [x509.NameAttribute(NameOID.COMMON_NAME, common_name)]
+    if organization:
+        name_attributes.append(x509.NameAttribute(NameOID.ORGANIZATION_NAME, organization))
+    if country:
+        name_attributes.append(x509.NameAttribute(NameOID.COUNTRY_NAME, country))
+    subject = x509.Name(name_attributes)
+    now = datetime.utcnow()
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + timedelta(days=validity_days))
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .sign(private_key=key, algorithm=hashes.SHA256())
+    )
+    keystore_bytes = pkcs12.serialize_key_and_certificates(
+        name=alias.encode("utf-8"),
+        key=key,
+        cert=certificate,
+        cas=None,
+        encryption_algorithm=serialization.BestAvailableEncryption(password.encode("utf-8")),
+    )
+    return keystore_bytes, certificate
+
+
+def materialize_project(files: Dict[str, str], destination: Path) -> None:
+    for relative, content in files.items():
+        target = destination / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+        if target.suffix == ".sh":
+            target.chmod(0o755)
+
+
+def run_gradle_tasks(project_dir: Path, tasks: List[str]) -> Tuple[List[Path], str, int]:
+    command: List[str] | None = None
+    wrapper = project_dir / "gradlew"
+    if wrapper.exists():
+        command = ["./gradlew", *tasks]
+    elif shutil.which("gradle"):
+        command = ["gradle", *tasks]
+    else:
+        message = (
+            "Gradle wrapper not found and 'gradle' command is unavailable. Install Android Studio "
+            "or Gradle, then run tools/build_release.sh."
+        )
+        return [], message, 127
+
+    try:
+        result = subprocess.run(
+            command,
+            cwd=project_dir,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        return [], f"Failed to execute {' '.join(command)}: {exc}", 127
+
+    log_output = (result.stdout or "") + ("\n" + result.stderr if result.stderr else "")
+    artifacts: List[Path] = []
+    if result.returncode == 0:
+        candidates = [
+            project_dir / "app" / "build" / "outputs" / "apk" / "release" / "app-release.apk",
+            project_dir / "app" / "build" / "outputs" / "bundle" / "release" / "app-release.aab",
+        ]
+        for candidate in candidates:
+            if candidate.exists():
+                artifacts.append(candidate)
+    return artifacts, log_output.strip(), result.returncode
+
+
+def certificate_summary(certificate: x509.Certificate) -> str:
+    fingerprint = certificate.fingerprint(hashes.SHA256()).hex()
+    lines = [
+        f"Subject: {certificate.subject.rfc4514_string()}",
+        f"Issuer: {certificate.issuer.rfc4514_string()}",
+        f"Serial: {certificate.serial_number}",
+        f"Valid from: {certificate.not_valid_before.isoformat()}",
+        f"Valid to: {certificate.not_valid_after.isoformat()}",
+        f"Signature hash: {certificate.signature_hash_algorithm.name}",
+        "",
+        f"SHA-256 fingerprint: {fingerprint}",
+    ]
+    return "\n".join(lines)
+
+
+def generate_release_package(
+    app_name: str,
+    package_name: str,
+    start_url: str,
+    rules: Dict[str, object],
+    signing_details: Dict[str, str],
+) -> Tuple[io.BytesIO, str, List[str], int]:
+    signing_config = {
+        "store_file": "release.keystore",
+        "store_password": signing_details["store_password"],
+        "key_alias": signing_details["key_alias"],
+        "key_password": signing_details["key_password"],
+        "store_type": "pkcs12",
+    }
+    files = create_project_files(app_name, package_name, start_url, rules, signing_config=signing_config)
+    keystore_bytes, cert = create_release_keystore(
+        signing_details["key_alias"],
+        signing_details["store_password"],
+        signing_details["common_name"],
+        signing_details.get("organization", ""),
+        signing_details.get("country", ""),
+        signing_details.get("validity_days", 3650),
+    )
+
+    certificate_info = certificate_summary(cert)
+
+    with tempfile.TemporaryDirectory() as tmpdir_str:
+        tmpdir = Path(tmpdir_str)
+        materialize_project(files, tmpdir)
+        keystore_path = tmpdir / signing_config["store_file"]
+        keystore_path.write_bytes(keystore_bytes)
+        keystore_path.chmod(0o600)
+
+        artifacts, log_output, exit_code = run_gradle_tasks(
+            tmpdir, ["assembleRelease", "bundleRelease"]
+        )
+
+        bundle = io.BytesIO()
+        with zipfile.ZipFile(bundle, mode="w") as archive:
+            for root, _, filenames in os.walk(tmpdir):
+                for filename in filenames:
+                    file_path = Path(root) / filename
+                    arcname = Path("project") / file_path.relative_to(tmpdir)
+                    archive.write(file_path, str(arcname))
+            archive.writestr("project/RELEASE_CERTIFICATE.txt", certificate_info + "\n")
+
+            if log_output:
+                archive.writestr("outputs/build.log", log_output + "\n")
+            for artifact in artifacts:
+                archive.write(artifact, f"outputs/{artifact.name}")
+
+        bundle.seek(0)
+    artifact_names = [artifact.name for artifact in artifacts]
+    return bundle, certificate_info, artifact_names, exit_code
+
+
+def form_errors(app_name: str, package_name: str, start_url: str) -> List[str]:
+    errors: List[str] = []
+    if not app_name.strip():
+        errors.append("App name is required.")
+    if not package_name.strip():
+        errors.append("Package name is required.")
+    elif not validate_package_name(package_name):
+        errors.append(
+            "Package name must follow the Java package naming convention (e.g. com.example.app)."
+        )
+    if not start_url.strip():
+        errors.append("A start URL is required for the WebView to load.")
+    return errors
+
+
+@app.before_request
+def ensure_rules_loaded() -> None:
+    """Make sure we have the latest cached rule manifest."""
+    rule_monitor.load()
+
+
+@app.route("/", methods=["GET"])
+def index() -> str:
+    rules = rule_monitor.load()
+    return render_template(
+        "index.html",
+        rules=rules,
+    )
+
+
+@app.route("/generate", methods=["POST"])
+def generate() -> Response:
+    app_name = request.form.get("app_name", "").strip()
+    package_name = request.form.get("package_name", "").strip()
+    start_url = request.form.get("start_url", "").strip()
+
+    errors = form_errors(app_name, package_name, start_url)
+    if errors:
+        for message in errors:
+            flash(message, "error")
+        return redirect(url_for("index"))
+
+    rules = rule_monitor.load()
+    archive = build_project_zip(app_name, package_name, start_url, rules)
+    filename = f"{package_name.split('.')[-1]}-webview-app.zip"
+    return send_file(
+        archive,
+        mimetype="application/zip",
+        as_attachment=True,
+        download_name=filename,
+    )
+
+
+@app.route("/generate-release", methods=["POST"])
+def generate_release() -> Response:
+    app_name = request.form.get("app_name", "").strip()
+    package_name = request.form.get("package_name", "").strip()
+    start_url = request.form.get("start_url", "").strip()
+
+    errors = form_errors(app_name, package_name, start_url)
+
+    alias = request.form.get("key_alias", "release").strip() or "release"
+    store_password = request.form.get("keystore_password", "").strip()
+    key_password = request.form.get("key_password", "").strip() or store_password
+    common_name = request.form.get("signing_common_name", app_name).strip() or app_name
+    organization = request.form.get("signing_organization", "").strip()
+    country = request.form.get("signing_country", "").strip().upper()
+    validity_raw = request.form.get("signing_validity", "3650").strip()
+
+    if not store_password:
+        errors.append("A keystore password is required for signing.")
+    if not key_password:
+        errors.append("A key password is required for signing.")
+    if country and (len(country) != 2 or not country.isalpha()):
+        errors.append("Country code must be a two-letter ISO code (e.g. US).")
+    try:
+        validity_days = max(1, int(validity_raw or "3650"))
+    except ValueError:
+        errors.append("Certificate validity must be a number of days.")
+        validity_days = 3650
+
+    if errors:
+        for message in errors:
+            flash(message, "error")
+        return redirect(url_for("index"))
+
+    rules = rule_monitor.load()
+
+    signing_details = {
+        "key_alias": alias,
+        "store_password": store_password,
+        "key_password": key_password,
+        "common_name": common_name,
+        "organization": organization,
+        "country": country,
+        "validity_days": validity_days,
+    }
+
+    try:
+        bundle, _certificate_info, artifact_names, exit_code = generate_release_package(
+            app_name,
+            package_name,
+            start_url,
+            rules,
+            signing_details,
+        )
+    except Exception as exc:  # noqa: BLE001 - surface for user feedback
+        app.logger.exception("Failed to generate release bundle")
+        flash(f"Failed to generate release bundle: {exc}", "error")
+        return redirect(url_for("index"))
+
+    if exit_code == 0 and artifact_names:
+        artifact_list = ", ".join(artifact_names)
+        flash(f"Release bundle ready with artifacts: {artifact_list}.", "success")
+    else:
+        flash(
+            "Release bundle generated. Check outputs/build.log inside the archive for build details.",
+            "warning",
+        )
+
+    filename = f"{package_name.split('.')[-1]}-release-package.zip"
+    return send_file(
+        bundle,
+        mimetype="application/zip",
+        as_attachment=True,
+        download_name=filename,
+    )
+
+
+@app.route("/refresh-rules", methods=["POST"])
+def refresh_rules() -> Response:
+    rules = rule_monitor.refresh()
+    flash(
+        f"Rules refreshed: version {rules.get('version', 'unknown')} (source: {rule_monitor.remote_source})",
+        "success",
+    )
+    return redirect(url_for("index"))
+
+
+@app.route("/api/sdk-rules", methods=["GET"])
+def api_rules() -> Response:
+    rules = rule_monitor.load()
+    return jsonify({
+        "rules": rules,
+        "source": rule_monitor.remote_source,
+    })
+
+
+@app.route("/health", methods=["GET"])
+def health() -> Response:
+    return jsonify({"status": "ok", "updated": rule_monitor.load().get("updated")})
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", "5000"))
+    debug = os.environ.get("FLASK_DEBUG", "false").lower() == "true"
+    app.run(host="0.0.0.0", port=port, debug=debug)

--- a/data/sdk_rules.json
+++ b/data/sdk_rules.json
@@ -1,0 +1,13 @@
+{
+  "version": "2024.04",
+  "updated": "2024-04-10T12:00:00Z",
+  "notes": [
+    "This offline cache is bundled so AppMaker can start even without network access.",
+    "Use the Refresh rules button to download the latest Android policy manifest."
+  ],
+  "requirements": [
+    "Target API level 34 or above for new submissions.",
+    "Declare data safety information for WebView usage in Play Console.",
+    "Audit embedded web content for third-party cookies and trackers."
+  ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask==3.0.2
+cryptography==42.0.5

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,203 @@
+:root {
+    color-scheme: light dark;
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background: radial-gradient(circle at top left, #f5f7fa, #e4ecf7);
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    color: #1f2933;
+}
+
+header, footer {
+    background: rgba(15, 23, 42, 0.85);
+    color: #f8fafc;
+    padding: 2rem;
+    text-align: center;
+    box-shadow: 0 10px 40px rgba(15, 23, 42, 0.3);
+}
+
+header h1 {
+    margin: 0 0 0.5rem;
+    font-size: clamp(2.2rem, 4vw, 3rem);
+}
+
+main {
+    width: min(960px, 90%);
+    margin: -3rem auto 3rem;
+    background: rgba(255, 255, 255, 0.85);
+    backdrop-filter: blur(12px);
+    border-radius: 1.5rem;
+    padding: 2.5rem;
+    box-shadow: 0 30px 60px rgba(15, 23, 42, 0.15);
+}
+
+section + section {
+    margin-top: 2.5rem;
+}
+
+h2 {
+    font-size: 1.5rem;
+    margin-bottom: 1rem;
+    color: #0f172a;
+}
+
+.builder-form {
+    display: grid;
+    gap: 1.5rem;
+}
+
+label {
+    display: flex;
+    flex-direction: column;
+    font-weight: 600;
+    gap: 0.5rem;
+}
+
+input[type="text"],
+input[type="url"],
+input[type="password"],
+input[type="number"] {
+    padding: 0.75rem 1rem;
+    border-radius: 0.75rem;
+    border: 1px solid rgba(15, 23, 42, 0.2);
+    background: rgba(255, 255, 255, 0.9);
+    font-size: 1rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus {
+    outline: none;
+    border-color: #2563eb;
+    box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.2);
+}
+
+.actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+}
+
+button {
+    justify-self: start;
+    background: linear-gradient(135deg, #2563eb, #4f46e5);
+    color: #fff;
+    border: none;
+    padding: 0.9rem 1.8rem;
+    border-radius: 999px;
+    font-size: 1rem;
+    font-weight: 700;
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 15px 30px rgba(79, 70, 229, 0.35);
+}
+
+button:active {
+    transform: translateY(1px);
+}
+
+.accent {
+    background: linear-gradient(135deg, #0ea5e9, #6366f1);
+}
+
+.signing {
+    background: rgba(15, 23, 42, 0.04);
+    border-radius: 1rem;
+    padding: 1.25rem 1.5rem;
+}
+
+.signing summary {
+    font-weight: 700;
+    cursor: pointer;
+    margin-bottom: 1rem;
+    outline: none;
+}
+
+.signing-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem 1.25rem;
+    margin-bottom: 1rem;
+}
+
+.hint {
+    margin: 0;
+    color: rgba(15, 23, 42, 0.75);
+    font-size: 0.95rem;
+}
+
+.messages {
+    width: min(960px, 90%);
+    margin: 1.5rem auto 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.message {
+    padding: 1rem 1.5rem;
+    border-radius: 0.75rem;
+    font-weight: 600;
+}
+
+.message.error {
+    background: rgba(248, 113, 113, 0.15);
+    color: #b91c1c;
+}
+
+.message.success {
+    background: rgba(74, 222, 128, 0.15);
+    color: #047857;
+}
+
+.rules, .notes {
+    background: rgba(241, 245, 249, 0.9);
+    border-radius: 1rem;
+    padding: 1.5rem;
+    box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.rules ul, .notes ul {
+    margin: 0;
+    padding-left: 1.25rem;
+}
+
+.last-update {
+    font-style: italic;
+    color: rgba(15, 23, 42, 0.8);
+}
+
+pre {
+    background: rgba(15, 23, 42, 0.9);
+    color: #f8fafc;
+    padding: 1rem 1.5rem;
+    border-radius: 0.75rem;
+    overflow-x: auto;
+}
+
+@media (max-width: 640px) {
+    main {
+        padding: 1.75rem;
+    }
+
+    header, footer {
+        padding: 1.5rem;
+    }
+
+    .signing-grid {
+        grid-template-columns: 1fr;
+    }
+
+    button {
+        width: 100%;
+        justify-self: stretch;
+    }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AppMaker WebView Studio</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
+</head>
+<body>
+    <header>
+        <h1>AppMaker WebView Studio</h1>
+        <p>Create Android WebView shells that stay aligned with Google Play policies.</p>
+    </header>
+
+    {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+            <div class="messages">
+                {% for category, message in messages %}
+                    <div class="message {{ category }}">{{ message }}</div>
+                {% endfor %}
+            </div>
+        {% endif %}
+    {% endwith %}
+
+    <main>
+        <section class="builder">
+            <h2>1. Configure your WebView app</h2>
+            <form action="{{ url_for('generate') }}" method="post" class="builder-form">
+                <label>
+                    App name
+                    <input type="text" name="app_name" placeholder="My WebView App" required />
+                </label>
+                <label>
+                    Package name
+                    <input type="text" name="package_name" placeholder="com.example.webview" required />
+                    <small>Must follow Java package naming rules.</small>
+                </label>
+                <label>
+                    Launch URL
+                    <input type="url" name="start_url" placeholder="https://example.com" required />
+                </label>
+
+                <details class="signing">
+                    <summary>Advanced: signed release build (APK + AAB)</summary>
+                    <div class="signing-grid">
+                        <label>
+                            Keystore password
+                            <input type="password" name="keystore_password" placeholder="Required for signing" />
+                        </label>
+                        <label>
+                            Key password
+                            <input type="password" name="key_password" placeholder="Defaults to keystore password" />
+                        </label>
+                        <label>
+                            Key alias
+                            <input type="text" name="key_alias" placeholder="release" />
+                        </label>
+                        <label>
+                            Certificate common name
+                            <input type="text" name="signing_common_name" placeholder="My WebView App" />
+                        </label>
+                        <label>
+                            Organization (optional)
+                            <input type="text" name="signing_organization" placeholder="Example LLC" />
+                        </label>
+                        <label>
+                            Country code (ISO)
+                            <input type="text" name="signing_country" placeholder="US" maxlength="2" />
+                        </label>
+                        <label>
+                            Certificate validity (days)
+                            <input type="number" name="signing_validity" value="3650" min="1" />
+                        </label>
+                    </div>
+                    <p class="hint">Provide signing info to bundle a keystore, certificate summary, and build outputs ready for Play Store upload.</p>
+                </details>
+
+                <div class="actions">
+                    <button type="submit" class="primary">Generate Android project</button>
+                    <button type="submit" class="accent" formaction="{{ url_for('generate_release') }}">Build signed release package</button>
+                </div>
+            </form>
+        </section>
+
+        <section class="updates">
+            <h2>2. Keep up with Google Play SDK rules</h2>
+            <p class="last-update">Last synced: {{ rules.updated or 'unknown' }} (version {{ rules.version or 'n/a' }})</p>
+            <form action="{{ url_for('refresh_rules') }}" method="post">
+                <button type="submit">Refresh rules from Google</button>
+            </form>
+            <div class="rules">
+                <h3>Current requirements</h3>
+                {% if rules.requirements %}
+                    <ul>
+                        {% for item in rules.requirements %}
+                            <li>{{ item }}</li>
+                        {% endfor %}
+                    </ul>
+                {% else %}
+                    <p>No requirements loaded yet. Run the refresh button to update or configure <code>SDK_RULE_SOURCE</code>.</p>
+                {% endif %}
+            </div>
+            {% if rules.notes %}
+                <div class="notes">
+                    <h3>Notes</h3>
+                    <ul>
+                        {% for item in rules.notes %}
+                            <li>{{ item }}</li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            {% endif %}
+        </section>
+
+        <section class="api">
+            <h2>3. Automate your pipeline</h2>
+            <p>Use the <code>/api/sdk-rules</code> endpoint to programmatically check for updates and trigger builds.</p>
+            <pre><code>curl {{ request.host_url }}api/sdk-rules</code></pre>
+        </section>
+    </main>
+
+    <footer>
+        <p>Generated project includes an updater script so you can stay compliant when Google updates their SDK requirements.</p>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add backend helpers to create PKCS#12 keystores, run Gradle tasks, and package release artifacts
- expose advanced signing controls in the UI with refreshed styling for triggering signed builds
- document the release workflow and include the cryptography dependency required for keystore generation

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_b_68dbf47668a883299d9e9ac757438617